### PR TITLE
Enable path expansion by dot

### DIFF
--- a/cd-extras/public/Core.ps1
+++ b/cd-extras/public/Core.ps1
@@ -149,7 +149,8 @@ function Expand-Path {
   [string]$wildcardedPath =
   $Candidate -replace '(\w/|\w\\|\w$)', '$0*' `
     -replace '(/\*|\\\*)', ('*' + [System.IO.Path]::DirectorySeparatorChar) `
-    -replace '(/$|\\$)', '$0*'
+    -replace '(/$|\\$)', '$0*' `
+    -replace '(\.\w|\.$)', '*$0'
 
   if ($SearchPaths -and -not (IsRootedOrRelative $Candidate)) {
     # always include the local path, regardeless of whether it was passed

--- a/test/cd-extras.tests.ps1
+++ b/test/cd-extras.tests.ps1
@@ -1,0 +1,23 @@
+import-module pester -MinimumVersion 4.0
+. "$PSScriptRoot\..\cd-extras\public\Core.ps1"
+
+Describe "Path expansion" {
+    Context "scenario 1" {
+        In "testdrive:" {
+            mkdir "namespace"
+            mkdir "namespace/namespace.subnamespace"
+            mkdir "namespace/namespace.somethingelse"
+            mkdir "namespace/something"
+           
+            It "Should expand by path endings" {
+                $p = Expand-Path "n/.subna"
+                $p.fullname | Should -Be ((get-item "testdrive:").fullname + "namespace\namespace.subnamespace")
+            }
+            It "Should expand shorthand paths" {
+                $p = Expand-Path "n/s"
+                $p.fullname | Should -Be ((get-item "testdrive:").fullname + "namespace\something")
+            }           
+        }
+    }
+    
+}


### PR DESCRIPTION
Add dot (.) char to separators that cause wildcard expansion (together with a simple Pester test case).

## Rationale:

I often find myself navigating a directory structure like this:

```
src/SomeProject/
              /SomeProject.Core/
              /SomeProject.Lib/
             /SomeProject.(...)/
```

In this case, something like:
```
cd s/s/.c/
```
Should expand to:
```
cd src/SomeProject/SomeProject.Core/
```