### PR TITLE
loosen filter to re-enable multi-dot syntax

### DIFF
--- a/cd-extras/private/CommandNotFound.ps1
+++ b/cd-extras/private/CommandNotFound.ps1
@@ -9,7 +9,7 @@ function CommandNotFound($actions, $isUnderTest) {
     if ($MyInvocation.Line -match "$([regex]::Escape($CommandName))\s*\|") { return }
 
     # don't run if no word characters given
-    if ($MyInvocation.Line -notmatch '\w') { return }
+    if ($MyInvocation.Line -notmatch '\w|^\.{3,}$') { return }
 
     # don't run unless invoked interactively
     if ($CommandLookupEventArgs.CommandOrigin -ne 'Runspace' -and !(&$isUnderTest)) { return }


### PR DESCRIPTION
Thanks for the great tool. I use it all the time.
I just reinstalled on a new machine and noticed that mult-dot i.e '...' was no longer working.

I tracked it down to this commit:
https://github.com/nickcox/cd-extras/commit/cf200745fc76fa6204143e068c99b89eafe1933b

I've made an attempt at a fix, but perhaps you will think of a cleaner way to do this.